### PR TITLE
nested_sideload_hash compat with to_hash fix

### DIFF
--- a/lib/jsonapi_compliable/sideload.rb
+++ b/lib/jsonapi_compliable/sideload.rb
@@ -104,7 +104,7 @@ module JsonapiCompliable
     def nested_sideload_hash(sideload, levels_deep)
       {}.tap do |hash|
         if sideloading = sideload.resource_class.sideloading
-          hash.merge!(sideloading.to_hash(levels_deep)[:base])
+          hash.merge!(sideloading.to_hash(levels_deep)[:base] || {})
         end
       end
     end


### PR DESCRIPTION
sideloading.to_hash returns a hash without the :base key on occasion, causing a `no implicit conversion of nil into Hash` to be thrown by `merge!`.